### PR TITLE
Switch to stable dns for docker internal network

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,7 +18,7 @@ services:
       - ./sample_config.yaml:/indexify/config/indexify.yaml:ro
     environment:
       - OPENAI_API_KEY
-      - DATABASE_URL=postgres://postgres:postgres@172.20.0.5/indexify
+      - DATABASE_URL=postgres://postgres:postgres@host.docker.internal/indexify
     depends_on:
       - qdrant
       - postgres

--- a/local_config.yaml
+++ b/local_config.yaml
@@ -16,7 +16,7 @@ openai:
   api_key: xxxxx
 
 # Database URL for storing document and memory
-db_url: postgres://postgres:postgres@localhost/indexify
+db_url: postgres://postgres:postgres@host.docker.internal/indexify
 
 coordinator_addr: 0.0.0.0:8950
 

--- a/sample_config.yaml
+++ b/sample_config.yaml
@@ -16,7 +16,7 @@ openai:
   api_key: xxxxx
 
 # Database URL for storing document and memory
-db_url: postgres://postgres:postgres@172.20.0.5/indexify
+db_url: postgres://postgres:postgres@host.docker.internal/indexify
 
 coordinator_addr: 0.0.0.0:8950
 
@@ -34,4 +34,4 @@ executor_config:
 index_config:
   index_store: Qdrant
   qdrant_config:
-    addr: "http://172.20.0.8:6334"
+    addr: "http://host.docker.internal:6334"


### PR DESCRIPTION
Use the stable internal network dns that docker provides instead of hand defining ip addresses for the services. I've only tested this on OSX but generally speaking docker internal host dns is cross platform. 

This change was required because docker networking overlay works poorly on OSX due to the virtualization required to run Docker itself. This greatly limits the flexibility of ip tables and network configuration which resulted in a broken docker-compose startup on my M1 machine. 