### PR TITLE
Ability to invoke and test extractors locally

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ mod data_repository_manager;
 mod entity;
 mod executor;
 pub mod executor_server;
-mod extractors;
+pub mod extractors;
 mod index;
 mod internal_api;
 pub mod package;

--- a/src/package.rs
+++ b/src/package.rs
@@ -63,7 +63,7 @@ impl Packager {
 
         self.add_directory_to_tar(&mut tar, &self.code_dir)?;
 
-        tar.append_path_with_name(self.config_path.clone(), "indexify_extractor.yaml")?;
+        tar.append_path_with_name(self.config_path.clone(), "indexify.yaml")?;
 
         if self.dev {
             self.add_dev_dependencies(&mut tar)?;

--- a/src/server_config.rs
+++ b/src/server_config.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Result, Error};
 use figment::{
     providers::{Env, Format, Yaml},
     Figment,
@@ -224,6 +224,15 @@ impl ExecutorConfig {
             self.listen_port = port;
         }
         self
+    }
+
+    pub fn with_advertise_addr(mut self, addr: Option<String>) -> Result<Self, Error> {
+        if let Some(addr) = addr {
+            let sock_addr: SocketAddr = addr.parse()?;
+            self.advertise_if = NetworkAddress(sock_addr.ip().to_string());
+            self.listen_port = sock_addr.port() as u64;
+        }
+        Ok(self)
     }
 
     pub fn with_coordinator_addr(mut self, addr: String) -> Self {


### PR DESCRIPTION
Allows a developer to invoke an extractor locally without joining it with the control plane.

```
indexify extractor extract --text "hello world"
```
this assumes there is a indexify.yaml in the current directory 

Optionally you can pass in the indexify.yaml 
```
indexify extractor extract --text "hello world" -c /path/to/indexify.yaml 
```

Indexify.yaml looks like this -

```
name: diptanu/minilm-l6-extractor
version: 1
description: "Sentence Transformer based Mini LM L6 Embedding"
module: minilm_l6_embedding:MiniLML6Extractor
gpu: false
python_dependencies:
  - torch
  - transformers
system_dependencies:
  - curl
```


