### PR TITLE
Made it easier to test extractors locally

### DIFF
--- a/indexify_extractor_sdk/base_extractor.py
+++ b/indexify_extractor_sdk/base_extractor.py
@@ -51,12 +51,6 @@ class Extractor(ABC):
         pass
 
 
-    def extract_query_embeddings(self, query: str) -> List[float]:
-        """
-        Extracts embeddings from the query. Only embedding extractor needs to implement this method.
-        """
-        raise NotImplementedError("extract_query_embeddings is not implemented")
-
     @classmethod
     def schemas(cls) -> ExtractorSchema:
         """
@@ -66,8 +60,7 @@ class Extractor(ABC):
 
 class ExtractorWrapper:
 
-    def __init__(self, entry_point: str):
-        module_name, class_name = entry_point.split(":")
+    def __init__(self, module_name: str, class_name: str):
         self._module = import_module(module_name)
         self._cls = getattr(self._module, class_name)
         self._param_cls = get_type_hints(self._cls.extract).get("params", None)

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -56,7 +56,8 @@ impl ExtractorExecutor {
     ) -> Result<Self> {
         let executor_id = create_executor_id();
 
-        let extractor = extractors::create_extractor(extractor_config.clone())?;
+        let extractor =
+            extractors::create_extractor(&extractor_config.module, &extractor_config.name)?;
         let extractor_executor = Self {
             executor_config,
             extractor_config,
@@ -76,7 +77,8 @@ impl ExtractorExecutor {
         vector_index_manager: Arc<VectorIndexManager>,
         attribute_index_manager: Arc<AttributeIndexManager>,
     ) -> Result<Self> {
-        let extractor = extractors::create_extractor(extractor_config.clone())?;
+        let extractor =
+            extractors::create_extractor(&extractor_config.module, &extractor_config.name)?;
         let executor_id = create_executor_id();
         Ok(Self {
             executor_config,

--- a/src/extractors.rs
+++ b/src/extractors.rs
@@ -7,10 +7,11 @@ use std::str::FromStr;
 use std::{collections::HashMap, sync::Arc};
 use tracing::info;
 
+use crate::python_path;
+use crate::server_config::ExtractorConfig;
 use crate::{
     content_reader::ContentReader,
     internal_api::{self, ContentPayload, ExtractedContent},
-    server_config,
 };
 use pyo3::types::{PyList, PyString};
 
@@ -169,15 +170,32 @@ pub trait Extractor {
 
 #[tracing::instrument]
 pub fn create_extractor(
-    extractor_config: Arc<server_config::ExtractorConfig>,
+    extractor_path: &str,
+    name: &str,
 ) -> Result<ExtractorTS, anyhow::Error> {
-    let extractor = PythonExtractor::new(extractor_config.module.clone())?;
-    info!("extractor created: {}", extractor_config.name.clone());
+    let tokens: Vec<&str> = extractor_path.split(":").collect();
+    if tokens.len() != 2 {
+        return Err(anyhow!("invalid extractor path: {}", extractor_path));
+    }
+    let module_name = tokens[0].trim_end_matches(".py").replace("/", ".");
+    let class_name = tokens[1].trim();
+    let extractor = PythonExtractor::new(&module_name, class_name)?;
+    info!("extractor created: name: {}, python module: {}, class name: {}", name, module_name, class_name);
     Ok(Arc::new(extractor))
 }
 
-pub fn run_extractor(extractor_config: Arc<server_config::ExtractorConfig>, text: Option<String>, file_path: Option<String>) -> Result<Vec<ExtractedContent>, anyhow::Error> {
-    let extractor = create_extractor(extractor_config)?;
+pub fn run_extractor(extractor_path: Option<String>, text: Option<String>, file_path: Option<String>) -> Result<Vec<ExtractedContent>, anyhow::Error> {
+    let extractor_path = match extractor_path {
+        Some(extractor_path) => Ok(extractor_path),
+        None => {
+            info!("no module name provided, looking up indexify.yaml");
+            let extractor_config = ExtractorConfig::from_path("indexify.yaml".into())?;
+            Ok(extractor_config.name)
+        }
+    }?;
+    info!("looking up extractor at path: {}", &extractor_path);
+    python_path::set_python_path(&extractor_path)?;
+    let extractor = create_extractor(&extractor_path, &extractor_path)?;
     let extracted_content = match (text, file_path) {
         (Some(text), None) => {
             let content = PyContent::new(text).try_into()?;
@@ -209,7 +227,7 @@ pub struct PythonExtractor {
 }
 
 impl PythonExtractor {
-    pub fn new(module_name: String) -> Result<Self, anyhow::Error> {
+    pub fn new(module_name: &str, class_name: &str) -> Result<Self, anyhow::Error> {
         let extractor_wrapper = Python::with_gil(|py| {
             let syspath: &PyList = py
                 .import("sys")?
@@ -222,9 +240,10 @@ impl PythonExtractor {
                 PyString::new(py, "indexify_extractor_sdk.base_extractor"),
             )?;
             let extractor_wrapper_class = module.getattr(PyString::new(py, "ExtractorWrapper"))?;
-            let entry_point = PyString::new(py, &module_name);
+            let entry_point = module_name.to_owned().into_py(py);
+            let class_name = class_name.to_owned().into_py(py);
 
-            let extractor_wrapper = extractor_wrapper_class.call1((entry_point,))?.into_py(py);
+            let extractor_wrapper = extractor_wrapper_class.call1((entry_point, class_name))?.into_py(py);
             Ok(extractor_wrapper)
         })?;
         Ok(Self { extractor_wrapper })
@@ -331,7 +350,7 @@ mod tests {
         let content = vec![content1, content2];
 
         let extractor =
-            PythonExtractor::new("indexify_extractor_sdk.mock_extractor:MockExtractor".into())
+            PythonExtractor::new("indexify_extractor_sdk.mock_extractor".into(), "MockExtractor".into())
                 .unwrap();
 
         let input_params = serde_json::from_str("{\"a\":5,\"b\":\"recursive\"}").unwrap();
@@ -353,7 +372,7 @@ mod tests {
     #[test]
     fn extract_embedding() {
         let extractor =
-            PythonExtractor::new("minilm_l6_embedding:MiniLML6Extractor".into()).unwrap();
+            PythonExtractor::new("minilm_l6_embedding".into(), "MiniLML6Extractor".into()).unwrap();
 
         let content1 = PyContent::new("My name is Donald and I live in Seattle".to_string())
             .try_into()
@@ -369,7 +388,7 @@ mod tests {
     #[test]
     fn extract_from_blob() {
         let extractor = PythonExtractor::new(
-            "indexify_extractor_sdk.mock_extractor:MockExtractorNoInputParams".into(),
+            "indexify_extractor_sdk.mock_extractor".into(), "MockExtractorNoInputParams".into()
         )
         .unwrap();
 
@@ -386,7 +405,7 @@ mod tests {
     #[test]
     fn extract_index_schema() {
         let extractor =
-            PythonExtractor::new("indexify_extractor_sdk.mock_extractor:MockExtractor".into())
+            PythonExtractor::new("indexify_extractor_sdk.mock_extractor".into(), "MockExtractor".into())
                 .unwrap();
 
         let extractor_schema = extractor.schemas().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,3 +19,4 @@ mod test_util;
 mod vector_index;
 mod vectordbs;
 mod work_store;
+mod python_path;

--- a/src/python_path.rs
+++ b/src/python_path.rs
@@ -1,0 +1,42 @@
+use std::{env, path::PathBuf, process::Command};
+
+use anyhow::anyhow;
+
+pub fn set_python_path(path: &str) -> Result<(), anyhow::Error> {
+    let path = PathBuf::from(path);
+    let parent_path = path
+        .parent()
+        .ok_or(anyhow::anyhow!("error setting PYTHONPATH: invalid path"))?;
+    let path_str = parent_path
+        .to_str()
+        .ok_or(anyhow!("error setting PYTHONPATH: invalid path"))?;
+    let python_path = std::env::var("PYTHONPATH").unwrap_or("".to_string());
+    let mut site_packages: String = "".into();
+    if cfg!(target_os = "macos") {
+        if env::var("VIRTUAL_ENV").is_ok() {
+            // Use Python itself to get the site-packages path
+            let output = Command::new("python")
+                .arg("-c")
+                .arg("import site; print(site.getsitepackages()[0])")
+                .output()
+                .expect("Failed to execute Python");
+
+            let site_packages_path = if output.status.success() {
+                let path_str = String::from_utf8_lossy(&output.stdout);
+                let path_trimmed = path_str.trim();
+                Some(PathBuf::from(path_trimmed))
+            } else {
+                None
+            };
+            if let Some(site_packages_path) = site_packages_path {
+                site_packages = site_packages_path
+                    .to_str()
+                    .ok_or(anyhow!("error setting PYTHONPATH: invalid path"))?
+                    .into();
+            }
+        }
+    }
+    let new_python_path = format!("{}:{}:{}", python_path, path_str, site_packages);
+    env::set_var("PYTHONPATH", new_python_path);
+    Ok(())
+}


### PR DESCRIPTION
1. Made it easy to test an extractor by passing the path of the file 
2. Automatically setting the path of the virtualenv in macOS to workaround a bug in pyo3 - https://github.com/PyO3/pyo3/issues/1741

```
./target/debug/indexify extractor extract -e extractors/minilm_l6_embedding.py:MiniLML6Extractor --text "hello world"
```