### PR TITLE
Added validation for json schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "once_cell",
+ "serde",
  "version_check",
 ]
 
@@ -557,6 +558,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -742,6 +758,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "bytecount"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
 
 [[package]]
 name = "bytemuck"
@@ -1118,6 +1140,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1213,6 +1245,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3027ae1df8d41b4bed2241c8fdad4acc1e7af60c8e17743534b545e77182d678"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -1353,8 +1395,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1678,6 +1722,7 @@ dependencies = [
  "flate2",
  "hostname",
  "itertools 0.12.0",
+ "jsonschema",
  "local-ip-address",
  "migration",
  "mime",
@@ -1794,6 +1839,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 
 [[package]]
+name = "iso8601"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924e5d73ea28f59011fec52a0d12185d496a9b075d360657aed2a5707f701153"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1833,6 +1887,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonschema"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a071f4f7efc9a9118dfb627a0a94ef247986e1ab8606a4c806ae2b3aa3b6978"
+dependencies = [
+ "ahash 0.8.3",
+ "anyhow",
+ "base64 0.21.4",
+ "bytecount",
+ "clap",
+ "fancy-regex",
+ "fraction",
+ "getrandom",
+ "iso8601",
+ "itoa",
+ "memchr",
+ "num-cmp",
+ "once_cell",
+ "parking_lot",
+ "percent-encoding",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "time",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -2155,6 +2239,12 @@ dependencies = [
  "smallvec",
  "zeroize",
 ]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
 
 [[package]]
 name = "num-complex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ clap = { version = "^4", features = ["derive"] }
 figment = { version = "0.10.8", features = ["yaml", "env"] }
 hostname = { version = "^0" }
 itertools = "0.12.0"
+jsonschema = "0.17.1"
 mime = {version = "^0.3"}
 mime_guess = {version = "^2"}
 nanoid = { version = "0.4.0" }

--- a/indexify_extractor_sdk/base_extractor.py
+++ b/indexify_extractor_sdk/base_extractor.py
@@ -84,5 +84,6 @@ class ExtractorWrapper:
             if isinstance(v, EmbeddingSchema):
                 embedding_schemas[k] = v
                 continue
-        input_params = json.dumps(self._param_cls.model_json_schema() if self._param_cls else {})
-        return InternalExtractorSchema(embedding_schemas=embedding_schemas, input_params=input_params)
+        json_schema = self._param_cls.model_json_schema() if self._param_cls else {}
+        json_schema['additionalProperties'] = False
+        return InternalExtractorSchema(embedding_schemas=embedding_schemas, input_params=json.dumps(json_schema))

--- a/src/server.rs
+++ b/src/server.rs
@@ -291,7 +291,6 @@ async fn get_repository(
     }))
 }
 
-#[tracing::instrument]
 #[utoipa::path(
     post,
     path = "/repositories/{repository_name}/extractor_bindings",
@@ -315,7 +314,7 @@ async fn bind_extractor(
         .repository_manager
         .add_extractor_binding(
             &repository_name,
-            into_persistence_extractor_binding(&repository_name, payload.extractor_binding),
+            &into_persistence_extractor_binding(&repository_name, payload.extractor_binding),
         )
         .await
         .map_err(|e| {


### PR DESCRIPTION
We are now validating the input params of extractors 

```
diptanu@diptanus-mbp indexify % curl -X POST http://localhost:8900/repositories/default/extractor_bindings \
-H "Content-Type: application/json" \
-d '{
    "extractor": "diptanu/minilm-l6-extractor",
    "name": "minil62",
    "input_params": {
        "a": 1,
        "b": 2
    }
}'

failed to bind extractor: unable to validate input params for extractor binding: minil62, errors: Additional properties are not allowed ('a', 'b' were unexpected)
```