### PR TITLE
Extract API on the server endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1792,6 +1792,7 @@ dependencies = [
  "sea-query",
  "serde",
  "serde_json",
+ "serde_with",
  "serde_yaml",
  "smart-default",
  "strum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ sea-orm-migration = { version = "0.12", features = [
     "sqlx-postgres",
 ] }
 serde = { version = "1", features = ["derive"] }
+serde_with = {version="3.4.0"}
 serde_yaml = { version = "0.9" }
 serde_json = { version = "1" }
 smart-default = { version = "0.7" }
@@ -113,6 +114,7 @@ reqwest = { workspace = true }
 sea-orm = { workspace = true }
 sea-query = { workspace = true }
 serde = { workspace = true }
+serde_with = { workspace = true }
 serde_yaml = { workspace = true }
 serde_json = { workspace = true }
 smart-default = { workspace = true }

--- a/Makefile
+++ b/Makefile
@@ -54,3 +54,6 @@ shell:
 
 serve-docs:
 	(cd docs && mkdocs serve)
+
+fmt:
+	cargo +nightly fmt

--- a/src/api.rs
+++ b/src/api.rs
@@ -5,6 +5,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, BytesOrString};
 use smart_default::SmartDefault;
 use strum::{Display, EnumString};
 use utoipa::{IntoParams, ToSchema};
@@ -408,4 +409,42 @@ impl IntoResponse for IndexifyAPIError {
     fn into_response(self) -> Response {
         (self.status_code, self.message).into_response()
     }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, EnumString)]
+pub enum FeatureType {
+    #[strum(serialize = "embedding")]
+    Embedding,
+    #[strum(serialize = "ner")]
+    NamedEntity,
+    #[strum(serialize = "metadata")]
+    Metadata,
+    #[strum(serialize = "unknown")]
+    Unknown,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Feature {
+    pub feature_type: FeatureType,
+    pub name: String,
+    pub data: serde_json::Value,
+}
+
+#[serde_as]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Content {
+    pub content_type: String,
+    #[serde_as(as = "BytesOrString")]
+    pub source: Vec<u8>,
+    pub feature: Option<Feature>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ExtractRequest {
+    pub content: Content,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ExtractResponse {
+    pub content: Vec<Content>,
 }

--- a/src/extractor_router.rs
+++ b/src/extractor_router.rs
@@ -1,0 +1,78 @@
+use anyhow::{anyhow, Result};
+
+use crate::{
+    api::Content,
+    internal_api::{self, CoordinateResponse, ExtractResponse},
+};
+
+pub struct ExtractorRouter {
+    coordinator_addr: String,
+}
+
+impl ExtractorRouter {
+    pub fn new(coordinator_addr: &str) -> Self {
+        Self {
+            coordinator_addr: coordinator_addr.into(),
+        }
+    }
+
+    pub async fn extract_content(
+        &self,
+        extractor_name: &str,
+        content: Content,
+    ) -> Result<Vec<Content>, anyhow::Error> {
+        let request = internal_api::ExtractRequest {
+            content: internal_api::Content {
+                content_type: content.content_type,
+                source: content.source,
+                feature: None,
+            },
+        };
+
+        let coordinate_request = internal_api::CoordinateRequest {
+            extractor_name: extractor_name.to_string(),
+        };
+
+        let coordinate_response = reqwest::Client::new()
+            .post(&format!("http://{}/coordinates", self.coordinator_addr))
+            .json(&coordinate_request)
+            .send()
+            .await
+            .map_err(|e| anyhow::anyhow!("unable to get coordinates of extractor: {}", e))?
+            .json::<CoordinateResponse>()
+            .await
+            .map_err(|e| anyhow!("unable to decode coordinate response {}", e))?;
+        let extractor_addr = coordinate_response
+            .content
+            .get(0)
+            .ok_or(anyhow!("no extractor found"))?;
+        let resp = reqwest::Client::new()
+            .post(&format!("http://{}/extract", extractor_addr))
+            .json(&request)
+            .send()
+            .await
+            .map_err(|e| anyhow::anyhow!("unable to embed query: {}", e))?;
+
+        if !&resp.status().is_success() {
+            return Err(anyhow!(
+                "unable to extract query: status: {}, error: {}",
+                resp.status(),
+                resp.text().await?
+            ));
+        }
+        let response_body = resp
+            .text()
+            .await
+            .map_err(|e| anyhow!("unable to get response body: {}", e))?;
+
+        let extractor_response: ExtractResponse = serde_json::from_str(&response_body)
+            .map_err(|e| anyhow!("unable to extract response from json: {}", e))?;
+
+        let content = extractor_response
+            .content
+            .get(0)
+            .ok_or(anyhow!("no content was extracted"))?
+            .to_owned();
+        Ok(vec![content.into()])
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ mod coordinator;
 mod data_repository_manager;
 mod entity;
 mod executor;
+mod extractor_router;
 mod index;
 mod internal_api;
 mod persistence;

--- a/src/vectordbs/pg_vector.rs
+++ b/src/vectordbs/pg_vector.rs
@@ -147,7 +147,9 @@ impl VectorDb for PgVector {
         // After the table-name, and with an offset of 1 (because chunk_id is inserted),
         // every second item is the embedding The final query looks similar to:
         // INSERT INTO index_table (chunk_id, embedding) VALUES (chunk_id_1,
-        // embedding_1), (chunk_id_2, embedding_2), ..., (chunk_id_n, embedding_n);                                                |>(1+2*0)=$1 |>(2+2*0)=$2  |>(1+2*1)=$3 |>(2+2*4)=$4       |>(1+2*n)    |>(2+2*n)
+        // embedding_1), (chunk_id_2, embedding_2), ..., (chunk_id_n, embedding_n);
+        // |>(1+2*0)=$1 |>(2+2*0)=$2  |>(1+2*1)=$3 |>(2+2*4)=$4       |>(1+2*n)
+        // |>(2+2*n)
         let value_placeholders = chunks
             .iter()
             .enumerate()


### PR DESCRIPTION
Exposing an extract api on the server which will allow developers to invoke extractors from the api directly without ingesting content persisted in the long term storage.


```
curl  -X POST http://localhost:8900/extractors/minilm-l6-extractor/extract -H "Content-Type: application/json" -d '{"content": {"content_type": "text/plain", "source": "hello world"}}'
```