### PR TITLE
Added input params to extraction api request

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -188,7 +188,7 @@ pub struct ExtractorBindRequest {
 #[derive(Debug, Serialize, Deserialize, Default, ToSchema)]
 pub struct ExtractorBindResponse {
     #[serde(default)]
-    pub index_names: Vec<String>
+    pub index_names: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
@@ -444,7 +444,9 @@ pub struct Content {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ExtractRequest {
+    pub name: String,
     pub content: Content,
+    pub input_params: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/data_repository_manager.rs
+++ b/src/data_repository_manager.rs
@@ -216,7 +216,8 @@ impl DataRepositoryManager {
                 errors.join(",")
             ));
         }
-        let index_names = self.create_index(&extractor, repository, extractor_binding)
+        let index_names = self
+            .create_index(&extractor, repository, extractor_binding)
             .await?;
         data_repository
             .extractor_bindings

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -195,8 +195,14 @@ impl ExtractorExecutor {
     }
 
     #[tracing::instrument]
-    pub async fn extract(&self, content: Content) -> Result<Vec<Content>, anyhow::Error> {
-        let extracted_content = self.extractor.extract(vec![content], json!({}))?;
+    pub async fn extract(
+        &self,
+        content: Content,
+        input_params: Option<serde_json::Value>,
+    ) -> Result<Vec<Content>, anyhow::Error> {
+        let extracted_content = self
+            .extractor
+            .extract(vec![content], input_params.unwrap_or(json!({})))?;
         let content = extracted_content
             .get(0)
             .ok_or(anyhow!("no content was extracted"))?

--- a/src/executor_server.rs
+++ b/src/executor_server.rs
@@ -132,7 +132,9 @@ async fn extract(
     extractor_executor: State<Arc<ExtractorExecutor>>,
     Json(query): Json<ExtractRequest>,
 ) -> Result<Json<ExtractResponse>, IndexifyAPIError> {
-    let content = extractor_executor.extract(query.content).await;
+    let content = extractor_executor
+        .extract(query.content, query.input_params)
+        .await;
 
     match content {
         Ok(content) => Ok(Json(ExtractResponse { content })),

--- a/src/extractor_router.rs
+++ b/src/extractor_router.rs
@@ -20,6 +20,7 @@ impl ExtractorRouter {
         &self,
         extractor_name: &str,
         content: Content,
+        input_params: Option<serde_json::Value>,
     ) -> Result<Vec<Content>, anyhow::Error> {
         let request = internal_api::ExtractRequest {
             content: internal_api::Content {
@@ -27,6 +28,7 @@ impl ExtractorRouter {
                 source: content.source,
                 feature: None,
             },
+            input_params,
         };
 
         let coordinate_request = internal_api::CoordinateRequest {

--- a/src/internal_api.rs
+++ b/src/internal_api.rs
@@ -113,6 +113,7 @@ pub struct ExecutorInfo {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ExtractRequest {
     pub content: Content,
+    pub input_params: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/vector_index.rs
+++ b/src/vector_index.rs
@@ -117,7 +117,7 @@ impl VectorIndexManager {
         };
         let content = self
             .extractor_router
-            .extract_content(&index_info.extractor_name, content)
+            .extract_content(&index_info.extractor_name, content, None)
             .await
             .map_err(|e| IndexError::QueryEmbedding(e.to_string()))?
             .pop()


### PR DESCRIPTION
Parametizing the extraction api endpoint with input params that the extractor exposes

```
curl -X POST http://localhost:8900/extractors/extract -H "Content-Type: application/json" -d '{"name": "diptanu/minilm-l6-extractor", "content": {"content_type": "text/plain", "source": "hello world"}, "input_params": {"overlap": 5}}'
```