### PR TITLE
Added nightly toolchain step to setup docs

### DIFF
--- a/docs/docs/develop.md
+++ b/docs/docs/develop.md
@@ -11,6 +11,13 @@ Install various rust related tools -
 * Rust Compiler - <http://rustup.rs>
 * Cargo tools - clippy, rustfmt is very helpful for formating and fixing warnings.
 
+Install the "nightly" toolchain -
+
+```shell
+rustup update nightly
+rustup override set nightly
+```
+
 ### Python Dependencies
 
 Create a virtual env


### PR DESCRIPTION
Minor change to address #201 by adding a step to developer setup to install the rust nightly toolchain.