### PR TITLE
Upgrade axum and related dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,13 +461,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.3.4",
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.11",
+ "http-body 0.4.6",
+ "hyper 0.14.27",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d09dbe0e490df5da9d69b36dca48a76635288a82f92eca90024883a56202026d"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.2",
+ "axum-macros",
+ "bytes",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.1.0",
+ "hyper-util",
  "itoa",
  "matchit",
  "memchr",
@@ -485,6 +515,7 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -496,8 +527,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.11",
+ "http-body 0.4.6",
  "mime",
  "rustversion",
  "tower-layer",
@@ -505,10 +536,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "axum-macros"
-version = "0.3.8"
+name = "axum-core"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdca6a10ecad987bda04e95606ef85a5417dcaac1a78455242d72e031e2b6b62"
+checksum = "e87c8503f93e6d144ee5690907ba22db7ba79ab001a932ab99034f0fe836b3df"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a2edad600410b905404c594e2523549f1bcd4bded1e252c8f74524ccce0b867"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -518,17 +570,18 @@ dependencies = [
 
 [[package]]
 name = "axum-otel-metrics"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3f24cfb1bef7ab5f78d7e6833b1a39ec5ffea5018d3300c83082874681971b"
+checksum = "05498d33363e05a88a33e7071053c43bb3585c89e0bccb71b2ad06425b23b14f"
 dependencies = [
- "axum",
+ "axum 0.7.3",
  "futures-util",
- "http",
- "http-body",
- "opentelemetry 0.20.0",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "opentelemetry 0.21.0",
  "opentelemetry-prometheus",
- "opentelemetry-semantic-conventions 0.12.0",
+ "opentelemetry-semantic-conventions 0.13.0",
+ "opentelemetry_sdk 0.21.1",
  "pin-project-lite",
  "prometheus",
  "tower",
@@ -536,39 +589,42 @@ dependencies = [
 
 [[package]]
 name = "axum-server"
-version = "0.3.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9cfd9dbe28ebde5c0460067ea27c6f3b1d514b699c4e0a5aab0fb63e452a8a8"
+checksum = "c1ad46c3ec4e12f4a4b6835e173ba21c25e484c9d02b49770bf006ce5367c036"
 dependencies = [
  "arc-swap",
  "bytes",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.1.0",
+ "hyper-util",
  "pin-project-lite",
- "rustls 0.20.9",
- "rustls-pemfile 0.2.1",
+ "rustls",
+ "rustls-pemfile 2.0.0",
  "tokio",
- "tokio-rustls 0.23.4",
+ "tokio-rustls",
+ "tower",
  "tower-service",
 ]
 
 [[package]]
 name = "axum-tracing-opentelemetry"
-version = "0.14.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06985105829f176e9a3f113b1c71cc24e08f600ef0df4e70cd90d144f889e19f"
+checksum = "bdad298231394729042d1f155b93f9fdf0b5ee1aea0b62404c4d7341f7d8fe08"
 dependencies = [
- "axum",
+ "axum 0.7.3",
  "futures-core",
  "futures-util",
- "http",
- "opentelemetry 0.20.0",
+ "http 1.0.0",
+ "opentelemetry 0.21.0",
  "pin-project-lite",
  "tower",
  "tracing",
- "tracing-opentelemetry 0.21.0",
+ "tracing-opentelemetry",
  "tracing-opentelemetry-instrumentation-sdk",
 ]
 
@@ -586,12 +642,6 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
-
-[[package]]
-name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -698,15 +748,15 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f03db470b3c0213c47e978da93200259a1eb4dae2e5512cba9955e2b540a6fc6"
 dependencies = [
- "base64 0.21.5",
+ "base64",
  "bollard-buildkit-proto",
  "bollard-stubs",
  "bytes",
  "futures-core",
  "futures-util",
  "hex",
- "http",
- "hyper",
+ "http 0.2.11",
+ "hyper 0.14.27",
  "hyperlocal",
  "log",
  "num",
@@ -745,7 +795,7 @@ version = "1.43.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58071e8fd9ec1e930efd28e3a90c1251015872a2ce49f81f36421b86466932e"
 dependencies = [
- "base64 0.21.5",
+ "base64",
  "bollard-buildkit-proto",
  "bytes",
  "prost 0.12.3",
@@ -1524,7 +1574,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.11",
+ "indexmap 2.1.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d308f63daf4181410c242d34c11f928dcb3aa105852019e043c9d1f4e4368a"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 1.0.0",
  "indexmap 2.1.0",
  "slab",
  "tokio",
@@ -1631,13 +1700,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.11",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.0.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cb79eb393015dadd30fc252023adb0b2400a0caee0fa2a077e6e21a551e840"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
@@ -1678,9 +1781,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.22",
+ "http 0.2.11",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -1693,17 +1796,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5aa53871fc917b1a9ed87b683a5d86db645e23acb32c2e0785a353e522fb75"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.0",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
- "rustls 0.21.10",
+ "http 0.2.11",
+ "hyper 0.14.27",
+ "rustls",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -1712,7 +1834,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
+ "hyper 0.14.27",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -1725,10 +1847,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper",
+ "hyper 0.14.27",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdea9aac0dbe5a9240d68cfd9501e2db94222c6dc06843e06640b9e07f0fdc67"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "hyper 1.1.0",
+ "pin-project-lite",
+ "socket2 0.5.5",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1739,7 +1879,7 @@ checksum = "0fafdf7b2b2de7c9784f76e02c0935e65a8117ec3b768644379983ab333ac98c"
 dependencies = [
  "futures-util",
  "hex",
- "hyper",
+ "hyper 0.14.27",
  "pin-project",
  "tokio",
 ]
@@ -1790,8 +1930,7 @@ dependencies = [
  "anyhow",
  "askama",
  "async-trait",
- "axum",
- "axum-macros",
+ "axum 0.7.3",
  "axum-otel-metrics",
  "axum-server",
  "axum-tracing-opentelemetry",
@@ -1835,7 +1974,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "tracing-core",
- "tracing-opentelemetry 0.22.0",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "tracing-test",
  "tracing-unwrap",
@@ -1978,7 +2117,7 @@ checksum = "2a071f4f7efc9a9118dfb627a0a94ef247986e1ab8606a4c806ae2b3aa3b6978"
 dependencies = [
  "ahash 0.8.6",
  "anyhow",
- "base64 0.21.5",
+ "base64",
  "bytecount",
  "clap",
  "fancy-regex",
@@ -2193,14 +2332,14 @@ dependencies = [
 
 [[package]]
 name = "multer"
-version = "2.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01acbdc23469fd8fe07ab135923371d5f5a422fbf9c522158677c8eb15bc51c2"
+checksum = "a15d522be0a9c3e46fd2632e272d178f56387bdb5c9fbb3a36c649062e9b5219"
 dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http",
+ "http 1.0.0",
  "httparse",
  "log",
  "memchr",
@@ -2462,7 +2601,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd2846759315751e04d8b45a0bdbd89ce442282ffb916cf54f6b0adf8df4b44c"
 dependencies = [
- "base64 0.21.5",
+ "base64",
  "bytes",
  "dyn-clone",
  "lazy_static",
@@ -2554,7 +2693,7 @@ checksum = "c7594ec0e11d8e33faf03530a4c49af7064ebba81c1480e01be67d90b356508b"
 dependencies = [
  "async-trait",
  "bytes",
- "http",
+ "http 0.2.11",
  "opentelemetry_api",
  "reqwest",
 ]
@@ -2567,7 +2706,7 @@ checksum = "7e5e5a5c4135864099f3faafbe939eb4d7f9b80ebf68a8448da961b32a7c1275"
 dependencies = [
  "async-trait",
  "futures-core",
- "http",
+ "http 0.2.11",
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry-semantic-conventions 0.12.0",
@@ -2582,13 +2721,13 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-prometheus"
-version = "0.13.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d81bc254e2d572120363a2b16cdb0d715d301b5789be0cfc26ad87e4e10e53"
+checksum = "6f8f082da115b0dcb250829e3ed0b8792b8f963a1ad42466e48422fbe6a079bd"
 dependencies = [
  "once_cell",
- "opentelemetry_api",
- "opentelemetry_sdk 0.20.0",
+ "opentelemetry 0.21.0",
+ "opentelemetry_sdk 0.21.1",
  "prometheus",
  "protobuf",
 ]
@@ -2676,8 +2815,6 @@ dependencies = [
  "regex",
  "serde_json",
  "thiserror",
- "tokio",
- "tokio-stream",
 ]
 
 [[package]]
@@ -2699,6 +2836,8 @@ dependencies = [
  "rand",
  "serde_json",
  "thiserror",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -3303,15 +3442,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
 dependencies = [
  "async-compression",
- "base64 0.21.5",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.3.22",
+ "http 0.2.11",
+ "http-body 0.4.6",
+ "hyper 0.14.27",
  "hyper-rustls",
  "hyper-tls",
  "ipnet",
@@ -3322,7 +3461,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.10",
+ "rustls",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
@@ -3330,7 +3469,7 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
  "tokio-util",
  "tower-service",
  "url",
@@ -3344,21 +3483,6 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin 0.5.2",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
-]
-
-[[package]]
-name = "ring"
 version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
@@ -3367,7 +3491,7 @@ dependencies = [
  "getrandom",
  "libc",
  "spin 0.9.8",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.48.0",
 ]
 
@@ -3514,24 +3638,12 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
-dependencies = [
- "log",
- "ring 0.16.20",
- "sct",
- "webpki",
-]
-
-[[package]]
-name = "rustls"
 version = "0.21.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
 dependencies = [
  "log",
- "ring 0.17.7",
+ "ring",
  "rustls-webpki",
  "sct",
 ]
@@ -3550,21 +3662,28 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
-dependencies = [
- "base64 0.13.1",
-]
-
-[[package]]
-name = "rustls-pemfile"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64 0.21.5",
+ "base64",
 ]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35e4980fa29e4c4b212ffb3db068a564cbf560e51d3944b7c88bd8bf5bec64f4"
+dependencies = [
+ "base64",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e9d979b3ce68192e42760c7810125eb6cf2ea10efae545a156063e61f314e2a"
 
 [[package]]
 name = "rustls-webpki"
@@ -3572,8 +3691,8 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.7",
- "untrusted 0.9.0",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -3618,8 +3737,8 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.7",
- "untrusted 0.9.0",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -3886,7 +4005,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64cd236ccc1b7a29e7e2739f27c0b2dd199804abc4290e32f59f3b68d6405c23"
 dependencies = [
- "base64 0.21.5",
+ "base64",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -4197,7 +4316,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e37195395df71fd068f6e2082247891bc11e3289624bbc776a0cdfa1ca7f1ea4"
 dependencies = [
  "atoi",
- "base64 0.21.5",
+ "base64",
  "bigdecimal",
  "bitflags 2.4.1",
  "byteorder",
@@ -4244,7 +4363,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6ac0ac3b7ccd10cc96c7ab29791a7dd236bd94021f31eec7ba3d46a74aa1c24"
 dependencies = [
  "atoi",
- "base64 0.21.5",
+ "base64",
  "bigdecimal",
  "bitflags 2.4.1",
  "byteorder",
@@ -4598,22 +4717,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.23.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
-dependencies = [
- "rustls 0.20.9",
- "tokio",
- "webpki",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.10",
+ "rustls",
  "tokio",
 ]
 
@@ -4667,15 +4775,15 @@ checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
- "base64 0.21.5",
+ "axum 0.6.20",
+ "base64",
  "bytes",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.3.22",
+ "http 0.2.11",
+ "http-body 0.4.6",
+ "hyper 0.14.27",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -4683,7 +4791,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-pemfile 1.0.4",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
  "tokio-stream",
  "tower",
  "tower-layer",
@@ -4699,13 +4807,13 @@ checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
- "base64 0.21.5",
+ "axum 0.6.20",
+ "base64",
  "bytes",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.3.22",
+ "http 0.2.11",
+ "http-body 0.4.6",
+ "hyper 0.14.27",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -4785,17 +4893,6 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
@@ -4803,22 +4900,6 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-opentelemetry"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75327c6b667828ddc28f5e3f169036cb793c3f588d83bf0f262a7f062ffed3c8"
-dependencies = [
- "once_cell",
- "opentelemetry 0.20.0",
- "opentelemetry_sdk 0.20.0",
- "smallvec",
- "tracing",
- "tracing-core",
- "tracing-log 0.1.4",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -4834,22 +4915,21 @@ dependencies = [
  "smallvec",
  "tracing",
  "tracing-core",
- "tracing-log 0.2.0",
+ "tracing-log",
  "tracing-subscriber",
  "web-time",
 ]
 
 [[package]]
 name = "tracing-opentelemetry-instrumentation-sdk"
-version = "0.14.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f523eba1b52bb854b804d43a039aafeaee5a623015065adbfef8016825319c15"
+checksum = "9920abb6a3ee3a2af7d30c9ff02900f8481935d36723c3da95cf807468218e8c"
 dependencies = [
- "http",
- "opentelemetry-http",
- "opentelemetry_api",
+ "http 1.0.0",
+ "opentelemetry 0.21.0",
  "tracing",
- "tracing-opentelemetry 0.21.0",
+ "tracing-opentelemetry",
 ]
 
 [[package]]
@@ -4867,7 +4947,7 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log 0.2.0",
+ "tracing-log",
 ]
 
 [[package]]
@@ -4979,12 +5059,6 @@ checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -5039,11 +5113,11 @@ dependencies = [
 
 [[package]]
 name = "utoipa-rapidoc"
-version = "1.0.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54a9a294323cfd98cb7e210ffa3d65ec83f3c09b17b5c49ce17d9658101e162"
+checksum = "3d331839f6de584865f20c8138b73868d515ba62349ae4c8c1f78ffa54069e78"
 dependencies = [
- "axum",
+ "axum 0.7.3",
  "serde",
  "serde_json",
  "utoipa",
@@ -5051,11 +5125,11 @@ dependencies = [
 
 [[package]]
 name = "utoipa-redoc"
-version = "1.0.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c91925cf8fc316aaef77dcc6845770a62016c598d4114b63e991c3e7e5b0549"
+checksum = "01520ff2511e54c069eda8e93569fff9893b2548c53c1357655292f47ef6782f"
 dependencies = [
- "axum",
+ "axum 0.7.3",
  "serde",
  "serde_json",
  "utoipa",
@@ -5063,11 +5137,11 @@ dependencies = [
 
 [[package]]
 name = "utoipa-swagger-ui"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "154517adf0d0b6e22e8e1f385628f14fcaa3db43531dc74303d3edef89d6dfe5"
+checksum = "f839caa8e09dddc3ff1c3112a91ef7da0601075ba5025d9f33ae99c4cb9b6e51"
 dependencies = [
- "axum",
+ "axum 0.7.3",
  "mime_guess",
  "regex",
  "rust-embed",
@@ -5257,16 +5331,6 @@ checksum = "57099a701fb3a8043f993e8228dc24229c7b942e2b009a1b962e54489ba1d3bf"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
-dependencies = [
- "ring 0.17.7",
- "untrusted 0.9.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [".", "migration"]
 anyhow = { version = "1" }
 async-trait = "0.1"
 askama = { version = "0.12" }
-axum = { version = "0.6", features = ["multipart"] }
+axum = { version = "0.7", features = ["multipart"] }
 axum-macros = { version = "0.3" }
 axum-otel-metrics = "0.7"
 axum-tracing-opentelemetry = "0.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,10 @@ members = [".", "migration"]
 anyhow = { version = "1" }
 async-trait = "0.1"
 askama = { version = "0.12" }
-axum = { version = "0.7", features = ["multipart"] }
-axum-macros = { version = "0.3" }
-axum-otel-metrics = "0.7"
-axum-tracing-opentelemetry = "0.14"
-axum-server = { version = "0.3", features = ["tls-rustls"] }
+axum = { version = "0.7", features = ["multipart", "macros"] }
+axum-otel-metrics = "0.8"
+axum-tracing-opentelemetry = "0.16"
+axum-server = { version = "0.6", features = ["tls-rustls"] }
 bollard = { version = "0.15", features = ["buildkit"] }
 bytes = "1"
 clap = { version = "4", features = ["derive"] }
@@ -76,9 +75,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-unwrap = {version="0.10"}
 url = "2"
 utoipa = { version = "4", features = ["axum_extras"] }
-utoipa-swagger-ui = { version = "4", features = ["axum"] }
-utoipa-rapidoc = { version = "1", features = ["axum"] }
-utoipa-redoc = { version = "1", features = ["axum"] }
+utoipa-swagger-ui = { version = "5", features = ["axum"] }
+utoipa-rapidoc = { version = "2", features = ["axum"] }
+utoipa-redoc = { version = "2", features = ["axum"] }
 object_store = "0.8"
 local-ip-address = { version = "0.5" }
 flate2 = "1"
@@ -90,7 +89,6 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 askama = { workspace = true }
 axum = { workspace = true }
-axum-macros = { workspace = true }
 axum-server = { workspace = true }
 axum-otel-metrics = { workspace = true }
 axum-tracing-opentelemetry = { workspace = true }

--- a/src/cmd/extractor/extract.rs
+++ b/src/cmd/extractor/extract.rs
@@ -49,8 +49,8 @@ impl Args {
                 .unwrap_err_or_log();
         } else if let Some(extractor_path) = extractor_path {
             python_path::set_python_path(&extractor_path).unwrap();
-            let extractor = PythonExtractor::new_from_extractor_path(&extractor_path)
-            .unwrap_or_log();
+            let extractor =
+                PythonExtractor::new_from_extractor_path(&extractor_path).unwrap_or_log();
             let extractor: ExtractorTS = Arc::new(extractor);
             let py_content = match (text, file) {
                 (Some(text), None) => Ok(Content {

--- a/src/coordinator_service.rs
+++ b/src/coordinator_service.rs
@@ -83,8 +83,9 @@ impl CoordinatorServer {
             .layer(OtelAxumLayer::default())
             .layer(metrics)
             .layer(DefaultBodyLimit::disable());
-        axum::Server::bind(&self.addr)
-            .serve(app.into_make_service())
+
+        let listener = tokio::net::TcpListener::bind(&self.addr).await?;
+        axum::serve(listener, app.into_make_service())
             .with_graceful_shutdown(shutdown_signal())
             .await?;
         Ok(())

--- a/src/coordinator_service.rs
+++ b/src/coordinator_service.rs
@@ -102,7 +102,7 @@ async fn root() -> &'static str {
 }
 
 #[tracing::instrument]
-#[axum_macros::debug_handler]
+#[axum::debug_handler]
 async fn list_executors(
     State(coordinator): State<Arc<Coordinator>>,
 ) -> Result<Json<ListExecutors>, IndexifyAPIError> {
@@ -115,7 +115,7 @@ async fn list_executors(
 
 #[tracing::instrument(level = "debug", skip(coordinator))]
 #[tracing::instrument(skip(coordinator, executor))]
-#[axum_macros::debug_handler]
+#[axum::debug_handler]
 async fn sync_executor(
     State(coordinator): State<Arc<Coordinator>>,
     Json(executor): Json<SyncExecutor>,
@@ -158,7 +158,7 @@ async fn sync_executor(
 }
 
 #[tracing::instrument]
-#[axum_macros::debug_handler]
+#[axum::debug_handler]
 async fn get_coordinate(
     State(coordinator): State<Arc<Coordinator>>,
     Json(query): Json<CoordinateRequest>,
@@ -172,7 +172,7 @@ async fn get_coordinate(
     }))
 }
 
-#[axum_macros::debug_handler]
+#[axum::debug_handler]
 async fn create_work(
     State(coordinator): State<Arc<Coordinator>>,
     Json(create_work): Json<CreateWork>,

--- a/src/executor_server.rs
+++ b/src/executor_server.rs
@@ -122,8 +122,7 @@ impl ExecutorServer {
             error!("unable to send heartbeat: {:?}", err.to_string());
         }
         tokio::spawn(heartbeat(tx.clone(), rx, executor.clone()));
-        axum::Server::from_tcp(listener)?
-            .serve(app.into_make_service())
+        axum::serve(listener, app.into_make_service())
             .with_graceful_shutdown(shutdown_signal(tx.clone()))
             .await?;
         Ok(())

--- a/src/executor_server.rs
+++ b/src/executor_server.rs
@@ -1,7 +1,4 @@
-use std::{
-    net::{SocketAddr, TcpListener},
-    sync::Arc,
-};
+use std::{net::SocketAddr, sync::Arc};
 
 use anyhow::Result;
 use axum::{
@@ -12,7 +9,6 @@ use axum::{
 };
 use axum_otel_metrics::HttpMetricsLayerBuilder;
 use axum_tracing_opentelemetry::middleware::OtelAxumLayer;
-use reqwest::StatusCode;
 use tokio::{signal, sync::mpsc};
 use tracing::{error, info};
 
@@ -82,7 +78,7 @@ impl ExecutorServer {
 
     pub async fn run(&self) -> Result<(), anyhow::Error> {
         let addr: SocketAddr = self.executor_config.listen_addr_sock()?;
-        let listener = TcpListener::bind(addr)?;
+        let listener = tokio::net::TcpListener::bind(addr).await?;
         let listen_addr = listener.local_addr()?.to_string();
         let listen_port = listener.local_addr()?.port();
         let advertise_addr = format!("{}:{}", self.executor_config.advertise_if, listen_port);
@@ -135,7 +131,7 @@ async fn root() -> &'static str {
 }
 
 #[tracing::instrument]
-#[axum_macros::debug_handler]
+#[axum::debug_handler]
 async fn extract(
     extractor_executor: State<Arc<ExtractorExecutor>>,
     Json(query): Json<ExtractRequest>,
@@ -149,14 +145,14 @@ async fn extract(
         Err(err) => {
             error!("unable to extract content: {}", err.to_string());
             Err(IndexifyAPIError::new(
-                StatusCode::INTERNAL_SERVER_ERROR,
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
                 err.to_string(),
             ))
         }
     }
 }
 
-#[axum_macros::debug_handler]
+#[axum::debug_handler]
 async fn sync_worker(
     extractor_executor: State<Arc<ExtractorExecutor>>,
 ) -> Result<(), IndexifyAPIError> {

--- a/src/extractor/py_extractors.rs
+++ b/src/extractor/py_extractors.rs
@@ -156,11 +156,11 @@ impl PythonExtractor {
             let extractor_wrapper = extractor_wrapper_class
                 .call1((entry_point.clone(), class_name.clone()))?
                 .into_py(py);
-            let args= (entry_point, class_name);
+            let args = (entry_point, class_name);
             let schemas = module.call_method1("extractor_schema", args)?.into_py(py);
             let input_params: String = schemas.getattr(py, "input_params")?.extract(py)?;
             let input_params = serde_json::from_str(&input_params)?;
-            let embedding_schemas: HashMap<String, EmbeddingSchema> =schemas 
+            let embedding_schemas: HashMap<String, EmbeddingSchema> = schemas
                 .getattr(py, "embedding_schemas")?
                 .extract(py)
                 .map_err(|e| anyhow!(e.to_string()))?;
@@ -170,7 +170,10 @@ impl PythonExtractor {
             };
             Ok((extractor_wrapper, extractor_schema))
         })?;
-        Ok(Self { extractor_wrapper, extractor_schema })
+        Ok(Self {
+            extractor_wrapper,
+            extractor_schema,
+        })
     }
 }
 

--- a/src/package.rs
+++ b/src/package.rs
@@ -82,7 +82,8 @@ impl Packager {
             ..Default::default()
         };
 
-        let docker = Docker::connect_with_local_defaults().map_err(|e| anyhow!("unable to connect to docker {}", e))?;
+        let docker = Docker::connect_with_local_defaults()
+            .map_err(|e| anyhow!("unable to connect to docker {}", e))?;
 
         let mut image_build_stream =
             docker.build_image(build_image_options, None, Some(compressed.into()));

--- a/src/server.rs
+++ b/src/server.rs
@@ -228,8 +228,8 @@ impl Server {
             }
         } else {
             info!("server is listening at addr {}", &self.addr.to_string());
-            axum::Server::bind(&self.addr)
-                .serve(app.into_make_service())
+            let listener = tokio::net::TcpListener::bind(&self.addr).await?;
+            axum::serve(listener, app.into_make_service())
                 .with_graceful_shutdown(shutdown_signal())
                 .await?;
         }

--- a/src/server_config.rs
+++ b/src/server_config.rs
@@ -2,7 +2,7 @@ use std::{
     fmt,
     fs,
     net::{AddrParseError, IpAddr, Ipv4Addr, SocketAddr},
-    path::{PathBuf, Path},
+    path::{Path, PathBuf},
 };
 
 use anyhow::{anyhow, Error, Result};
@@ -256,7 +256,8 @@ pub struct TlsConfig {
 }
 
 /// TlsConfig converts to RustlsConfig
-/// If a relative path is provided, it is assumed to be relative to the project root
+/// If a relative path is provided, it is assumed to be relative to the project
+/// root
 impl TlsConfig {
     pub async fn into_rustlsconfig(self) -> Result<RustlsConfig> {
         let cert_file = TlsConfig::resolve_path(&self.cert_file);


### PR DESCRIPTION
Update axum and related dependencies

### Summary

    This change updates axum and related dependencies.

    - Update axum to 0.7 and enabled "macros" feature
    - Remove axum-macros (now included as a feature in Axum)
    - Update otel, swagger-ui, rapidoc, and redoc
    - Ran 'make fmt' which made some formatting changes across the repo.
    - Added macro to consolidate running of api server in http vs https.

### Testing Done

    cargo build
    cargo test
    Ran https server and tested base api route