### PR TITLE
Leader election

### DIFF
--- a/src/vector_index.rs
+++ b/src/vector_index.rs
@@ -7,7 +7,12 @@ use crate::{
     coordinator_client::CoordinatorClient,
     extractor::ExtractedEmbeddings,
     extractor_router::ExtractorRouter,
+<<<<<<< HEAD
     indexify_coordinator::Index,
+=======
+    grpc_helper::GrpcHelper,
+    indexify_coordinator::{self, CreateIndexRequest, Index},
+>>>>>>> f167db7 (Removing orm)
     internal_api::EmbeddingSchema,
     vectordbs::{CreateIndexParams, IndexDistance, VectorChunk, VectorDBTS},
 };

--- a/src/vector_index.rs
+++ b/src/vector_index.rs
@@ -7,12 +7,7 @@ use crate::{
     coordinator_client::CoordinatorClient,
     extractor::ExtractedEmbeddings,
     extractor_router::ExtractorRouter,
-<<<<<<< HEAD
     indexify_coordinator::Index,
-=======
-    grpc_helper::GrpcHelper,
-    indexify_coordinator::{self, CreateIndexRequest, Index},
->>>>>>> f167db7 (Removing orm)
     internal_api::EmbeddingSchema,
     vectordbs::{CreateIndexParams, IndexDistance, VectorChunk, VectorDBTS},
 };


### PR DESCRIPTION
* Hooked up scheduler with Raft's leader election process 
* Scheduler runs on the leader now now, but we can run this in parallel across all nodes in future for scale out.
* Scheduling is not yet reactive